### PR TITLE
RNEA with FATROP solver

### DIFF
--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -22,7 +22,7 @@ add_library(compiled_solver SHARED ${SOURCE_FILE})
 target_link_libraries(compiled_solver PRIVATE ${FATROP_LIB} ${BLASFEO_LIB})
 
 # Compilation flags
-target_compile_options(compiled_solver PRIVATE -O2 -fPIC)
+target_compile_options(compiled_solver PRIVATE -O3 -fPIC)
 
 # Install the shared library
 install(TARGETS compiled_solver LIBRARY DESTINATION lib)

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -2,10 +2,26 @@
 
 ### Setup
 
-Install Fatrop and Blasfeo.
+Install Fatrop and Blasfeo. Make sure the Blasfeo include directory is correct in CMakeLists.txt.
 
 ### Usage
 
 1. Copy `compiled_solver.c` file into this folder, that is generated when running examples with `compile_solver=True`.
 2. Compile in `/build` folder.
 3. Copy resulting library to `/lib` folder. Make sure the name `load_compiled_solver` is set correctly in the examples.
+
+
+### Euler
+
+Careful: Need to compile Fatrop and Blasfeo locally, since they cannot be installed on the server. Then their directories need to be included in CMakeLists.txt.
+
+To compile the solver:
+
+1. Load cmake module:
+```bash
+module load stack/2024-06 gcc/12.2.0 cmake/3.27.7
+```
+2. Run batch job:
+```bash
+sbatch --time=1:00:00 --mem-per-cpu=16G --wrap="make"
+```

--- a/helpers.py
+++ b/helpers.py
@@ -36,20 +36,6 @@ class Robot:
         self.ndx = self.nx - 1  # exclude quaternion
         self.dx_opt_indices = np.arange(self.ndx)  # all by default
 
-        # OCP weights
-        self.Q_weights = {
-            "scaling": 1e0,
-            "com": 1000,
-            "base_xy": 10,
-            "base_z": 500,
-            "base_rot": 500,
-            "joints": 10,
-        }
-        self.R_weights = {
-            "scaling": 1e-3,
-            "forces": 1,
-            "joints": 100,
-        }
         self.arm_ee_id = None
 
     def set_gait_sequence(self, gait_type, gait_nodes, dt):
@@ -63,23 +49,49 @@ class Robot:
         self.arm_f_des = f_des
         self.arm_vel_des = vel_des
 
-    def initialize_weights(self):
-        Q_diag = np.concatenate((
-            [self.Q_weights["com"]] * 6,
-            [self.Q_weights["base_xy"]] * 2,
-            [self.Q_weights["base_z"]],
-            [self.Q_weights["base_rot"]] * 3,
-            [self.Q_weights["joints"]] * self.nj
-        ))
-        R_diag = np.concatenate((
-            [self.R_weights["forces"]] * self.nf,
-            [self.R_weights["joints"]] * self.nj
-        ))
-        self.Q = self.Q_weights["scaling"] * np.diag(Q_diag)
-        self.R = self.R_weights["scaling"] * np.diag(R_diag)
+    def initialize_weights(self, dynamics):
+        if dynamics == "centroidal":
+            self.Q_diag = np.concatenate((
+                [1000] * 6,  # com
+                [10] * 2,  # base x/y
+                [500],  # base z
+                [500] * 3,  # base rot
+                [10] * self.nj,  # joint pos
+            ))
+            self.R_diag = np.concatenate((
+                [1e-3] * self.nf,  # forces
+                [1e-1] * self.nj,  # joint vel
+            ))
 
-        # Only consider optimized indices
-        self.Q = self.Q[self.dx_opt_indices][:, self.dx_opt_indices]
+        elif dynamics == "rnea":
+            Q_pos_diag = np.concatenate((
+                [0] * 2,  # base x/y
+                [1000],  # base z
+                [1000] * 3,  # base rot
+                [100] * self.nj,  # joint pos
+            ))
+            Q_vel_diag = np.concatenate((
+                [1000] * 3,  # base linear
+                [1000] * 3,  # base angular
+                [1] * self.nj,  # joint vel
+            ))
+            self.Q_diag = np.concatenate((Q_pos_diag, Q_vel_diag))
+            self.R_diag = np.concatenate((
+                [1e-4] * self.nv,  # velocities
+                [1e-4] * self.nj,  # joint torques
+                [1e-4] * self.nf,  # forces
+            ))
+
+        else:
+            raise ValueError(f"Dynamics: {dynamics} not supported")
+
+        self.Q = np.diag(self.Q_diag)
+        self.R = np.diag(self.R_diag)
+
+        if dynamics == "centroidal":
+            # Only consider optimized indices
+            # TODO: Add this for RNEA
+            self.Q = self.Q[self.dx_opt_indices][:, self.dx_opt_indices]
 
 
 class B2(Robot):

--- a/helpers.py
+++ b/helpers.py
@@ -67,7 +67,8 @@ class Robot:
             Q_pos_diag = np.concatenate((
                 [0] * 2,  # base x/y
                 [1000],  # base z
-                [1000] * 3,  # base rot
+                [1000] * 2,  # base rot x/y
+                [0],  # base rot z
                 [100] * self.nj,  # joint pos
             ))
             Q_vel_diag = np.concatenate((

--- a/helpers.py
+++ b/helpers.py
@@ -156,6 +156,15 @@ class GaitSequence:
         shift_idx %= self.gait_nodes
         return np.roll(self.contact_schedule, -shift_idx, axis=1)
     
+    def get_bezier_pos_z(self, p0_z, idx, h=0.1):
+        # NOTE: idx needs to be in [0, N)
+        t = idx * self.dt
+        T = self.N * self.dt
+
+        p1_z = p0_z + h
+        p2_z = p0_z
+        return (1 - t / T)**2 * p0_z + 2 * (1 - t / T) * (t / T) * p1_z + (t / T)**2 * p2_z
+    
     def get_bezier_vel_z(self, p0_z, idx, h=0.1):
         # NOTE: idx needs to be in [0, N)
         t = idx * self.dt

--- a/ocp_rnea.py
+++ b/ocp_rnea.py
@@ -26,8 +26,6 @@ class OCP_RNEA:
         self.nj = robot.nj
 
         self.nodes = nodes
-        self.nf = robot.nf
-
         self.mass = self.data.mass[0]
         self.dt = self.gait_sequence.dt
         self.ee_ids = robot.ee_ids
@@ -247,7 +245,7 @@ class OCP_RNEA:
         if self.lam_g is not None:
             self.opti.set_initial(self.opti.lam_g, self.lam_g)
 
-    def init_solver(self, solver="fatrop", compile_solver=False):
+    def init_solver(self, solver="fatrop", compile_solver=False, warm_start=False):
         self.solver_type = solver
 
         if solver == "fatrop":
@@ -273,14 +271,20 @@ class OCP_RNEA:
                 solver_params = [
                     self.x_init,
                     self.contact_schedule,
-                    self.com_goal,
-                    self.arm_f_des,
-                    self.arm_vel_des,
                     self.Q_diag,
                     self.R_diag,
-                    self.opti.x,  # warm start (initial guess)
-                    # self.opti.lam_g,  # warm start (dual variables)
+                    self.com_goal
                 ]
+                if self.arm_ee_id:
+                    solver_params += [
+                        self.arm_f_des,
+                        self.arm_vel_des
+                    ]
+                if warm_start:
+                    solver_params += [
+                        self.opti.x,  # initial guess
+                        # self.opti.lam_g,  # dual variables
+                    ]
                 self.solver_function = self.opti.to_function(
                     "compiled_solver",
                     solver_params,

--- a/run_ocp_rnea.py
+++ b/run_ocp_rnea.py
@@ -31,7 +31,7 @@ def main():
     robot.set_gait_sequence(gait_type, gait_nodes, dt)
     if type(robot) == B2G and not robot.ignore_arm:
         robot.add_arm_task(arm_f_des, arm_vel_des)
-    robot.initialize_weights()
+    robot.initialize_weights(dynamics="rnea")
 
     robot_instance = robot.robot
     model = robot.model
@@ -49,6 +49,7 @@ def main():
     )
     ocp.set_com_goal(com_goal)
     ocp.set_arm_task(arm_f_des, arm_vel_des)
+    ocp.set_weights(robot.Q_diag, robot.R_diag)
 
     x_init = np.concatenate((q0, np.zeros(model.nv)))
     gait_idx = 0
@@ -64,8 +65,8 @@ def main():
         # lam_g_warm_start = ocp.opti.value(ocp.opti.lam_g, ocp.opti.initial())
 
         start_time = time.time()
-        sol_x = ocp.solver_function(x_init, contact_schedule, com_goal, arm_f_des, 
-                                    arm_vel_des, x_warm_start)
+        sol_x = ocp.solver_function(x_init, contact_schedule, com_goal, arm_f_des, arm_vel_des,
+                                    robot.Q_diag, robot.R_diag, x_warm_start)
         end_time = time.time()
         ocp.solve_time = end_time - start_time
 

--- a/run_ocp_rnea.py
+++ b/run_ocp_rnea.py
@@ -9,9 +9,9 @@ from ocp_rnea import OCP_RNEA
 # robot = B2(reference_pose="standing")
 robot = B2G(reference_pose="standing_with_arm_up", ignore_arm=False)
 gait_type = "trot"
-gait_nodes = 14
-ocp_nodes = 8
-dt = 0.03
+gait_nodes = 20
+ocp_nodes = 12
+dt = 0.025
 
 # Only for B2G
 arm_f_des = np.array([0, 0, 0])
@@ -19,6 +19,7 @@ arm_vel_des = np.array([0.1, 0, 0])
 
 # Tracking goal: linear and angular momentum
 com_goal = np.array([0.1, 0, 0, 0, 0, 0])
+step_height = 0.1
 
 # Solver
 solver = "fatrop"
@@ -48,6 +49,7 @@ def main():
         nodes=ocp_nodes,
     )
     ocp.set_com_goal(com_goal)
+    ocp.set_step_height(step_height)
     ocp.set_arm_task(arm_f_des, arm_vel_des)
     ocp.set_weights(robot.Q_diag, robot.R_diag)
 
@@ -82,6 +84,7 @@ def main():
             v = ocp.vs[k]
             tau = ocp.taus[k]
             forces = ocp.fs[k]
+            print("k: ", k)
             print("q: ", q.T)
             print("v: ", v.T)
             print("tau: ", tau.T)

--- a/run_ocp_rnea.py
+++ b/run_ocp_rnea.py
@@ -14,18 +14,18 @@ ocp_nodes = 8
 dt = 0.03
 
 # Only for B2G
-arm_f_des = np.array([0, 0, -100])
+arm_f_des = np.array([0, 0, 0])
 arm_vel_des = np.array([0.1, 0, 0])
 
 # Tracking goal: linear and angular momentum
 com_goal = np.array([0.1, 0, 0, 0, 0, 0])
 
-# Compiled solver
-solver = "osqp"
+# Solver
+solver = "fatrop"
 compile_solver = False
 load_compiled_solver = None
 
-debug = True  # print info
+debug = False  # print info
 
 
 def main():
@@ -91,7 +91,6 @@ def main():
                 f_ext[joint_id] = pin.Force(f)
 
             tau_rnea = pin.rnea(model, data, q, v, a, f_ext)
-            print("tau rnea: ", tau_rnea)
 
             tau_total = np.concatenate((np.zeros(6), tau))
             print("tau gap: ", tau_total - tau_rnea)


### PR DESCRIPTION
- Adapt RNEA OCP so it works with FATROP solver (diagonal structure needed)
  - Inputs are now defined as: [v_next_des, torques, forces]

- Changes in OCP constraints:
  - k = 0 not overconstrained: Remove foot velocity constraints
  - RNEA torque constraint only active for k = 0,1. After that the RNEA constraint is just active for the base (0 torque), effectively reducing the problem to centroidal dynamics (?)
  
- Additional changes:
  - Bezier velocity function was wrong!
  - Simplified bezier schedule parametrization. Added parameters for Q, R weights and step height. These can now be tuned in real-time in crl-loco.