### PR TITLE
Add cubic spline and fix centroidal formulation

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -96,7 +96,6 @@ class Robot:
             # Additional weights
             self.W_diag = np.concatenate((
                 [1e-1] * self.nj,  # keep tau_0 close to tau_prev
-                [1e-2] * self.nj,  # keep tau_1 close to tau_prev
             ))
 
         else:

--- a/ocp_rnea.py
+++ b/ocp_rnea.py
@@ -62,7 +62,7 @@ class OCP_RNEA:
 
         self.Q_diag = self.opti.parameter(self.ndx_opt)  # state weights
         self.R_diag = self.opti.parameter(self.nu_opt)  # input weights (with torques)
-        self.W_diag = self.opti.parameter(2 * self.nj)  # additional weights for joint torques
+        self.W_diag = self.opti.parameter(self.nj)  # additional weights for joint torques
         self.Q = ca.diag(self.Q_diag)
         self.R = ca.diag(self.R_diag)
         self.W = ca.diag(self.W_diag)
@@ -87,12 +87,10 @@ class OCP_RNEA:
             obj += 0.5 * err_dx.T @ self.Q @ err_dx
             obj += 0.5 * err_u.T @ self.R @ err_u
 
-        # Keep torques close to previous solution
+        # Keep torque close to previous solution
         tau_0 = self.U_opt[0][self.nv + self.nf :]
-        tau_1 = self.U_opt[1][self.nv + self.nf :]
-        tau_vec = ca.vertcat(tau_0, tau_1)
-        tau_goal = ca.vertcat(self.tau_prev, self.tau_prev)
-        err_tau = tau_vec - tau_goal
+        tau_des = self.tau_prev
+        err_tau = tau_0 - tau_des
         obj += 0.5 * err_tau.T @ self.W @ err_tau
 
         # Final state

--- a/run_mpc_centroidal.py
+++ b/run_mpc_centroidal.py
@@ -10,22 +10,27 @@ from ocp_centroidal import OCP_Centroidal
 # robot = B2(reference_pose="standing")
 robot = B2G(reference_pose="standing_with_arm_up", ignore_arm=False)
 gait_type = "trot"
-gait_nodes = 14
-ocp_nodes = 8
-dt = 0.03
+gait_nodes = 24
+ocp_nodes = 16
+dt = 0.02
 
 # Only for B2G
-arm_f_des = np.array([0, 0, -100])
-arm_vel_des = np.array([0.1, 0, 0])
+arm_f_des = np.array([0, 0, 0])
+arm_vel_des = np.array([0.3, 0, 0])
 
 # Tracking goal: linear and angular momentum
-com_goal = np.array([0.1, 0, 0, 0, 0, 0])
+com_goal = np.array([0.3, 0, 0, 0, 0, 0])
+
+# Swing params
+swing_height = 0.1
+swing_vel_limits = [0.2, -0.4]
 
 # MPC
 mpc_loops = 50
 
 # Solver
-solver = "osqp"
+solver = "fatrop"
+warm_start = True
 compile_solver = False
 load_compiled_solver = None
 # load_compiled_solver = "libsolver_trot_N8_dt03.so"
@@ -37,29 +42,47 @@ def mpc_loop(ocp, robot_instance, q0, N):
     x_init = np.concatenate((np.zeros(6), q0))
     solve_times = []
 
-    if load_compiled_solver:
-        # Load solver
-        compiled_solver = ca.external("compiled_solver", "codegen/lib/" + load_compiled_solver)
-        ocp.hs = []
-        ocp.qs = []
+    if compile_solver or load_compiled_solver:
+        if load_compiled_solver:
+            # Load solver
+            solver_function = ca.external("compiled_solver", "codegen/lib/" + load_compiled_solver)
+        else:
+            # Initialize solver
+            ocp.init_solver(solver=solver, compile_solver=compile_solver, warm_start=warm_start)
+            solver_function = ocp.solver_function
 
         for k in range(N):
-            # TODO: Look into warm-starting
-            contact_schedule = ocp.gait_sequence.shift_contact_schedule(k)[:,:ocp_nodes]
+            # Get parameters
+            ocp.update_initial_state(x_init)
+            ocp.update_gait_sequence(shift_idx=k)
+            contact_schedule = ocp.opti.value(ocp.contact_schedule)
+            swing_schedule = ocp.opti.value(ocp.swing_schedule)
+            n_contacts = ocp.opti.value(ocp.n_contacts)
+
+            params = [x_init, contact_schedule, swing_schedule, n_contacts, robot.Q_diag,
+                      robot.R_diag, com_goal, swing_height, swing_vel_limits]
+
+            if ocp.arm_ee_id:
+                params += [arm_f_des, arm_vel_des]
+            if warm_start:
+                ocp.warm_start()
+                x_warm_start = ocp.opti.value(ocp.opti.x, ocp.opti.initial())
+                params += [x_warm_start]
+
+            # Solve
             start_time = time.time()
-            DX_sol, U_sol = compiled_solver(x_init, contact_schedule, k, com_goal, arm_f_des, arm_vel_des)
+            sol_x = solver_function(*params)
             end_time = time.time()
             sol_time = end_time - start_time
             solve_times.append(sol_time)
 
             print("Solve time (ms): ", sol_time * 1000)
-            
-            x_init = ocp.dyn.state_integrate()(x_init, DX_sol)
-            h = np.array(x_init[:6])
-            q = np.array(x_init[6:])
-            ocp.hs.append(h)
-            ocp.qs.append(q)
-            robot_instance.display(q)
+
+            # Retract solution and update x_init
+            ocp._retract_stacked_sol(sol_x, retract_all=False)
+            x_init = ocp.dyn.state_integrate()(x_init, ocp.DX_prev[1])
+
+            robot_instance.display(ocp.qs[-1])  # Display last q
 
     else:
         # Initialize solver
@@ -67,7 +90,7 @@ def mpc_loop(ocp, robot_instance, q0, N):
 
         for k in range(N):
             ocp.update_initial_state(x_init)
-            ocp.update_contact_schedule(shift_idx=k)
+            ocp.update_gait_sequence(shift_idx=k)
             ocp.warm_start()
             ocp.solve(retract_all=False)
             solve_times.append(ocp.solve_time)
@@ -85,7 +108,7 @@ def main():
     robot.set_gait_sequence(gait_type, gait_nodes, dt)
     if type(robot) == B2G and not robot.ignore_arm:
         robot.add_arm_task(arm_f_des, arm_vel_des)
-    robot.initialize_weights()
+    robot.initialize_weights(dynamics="centroidal")
 
     robot_instance = robot.robot
     model = robot.model
@@ -106,7 +129,9 @@ def main():
         nodes=ocp_nodes,
     )
     ocp.set_com_goal(com_goal)
+    ocp.set_swing_params(swing_height, swing_vel_limits)
     ocp.set_arm_task(arm_f_des, arm_vel_des)
+    ocp.set_weights(robot.Q_diag, robot.R_diag)
     ocp = mpc_loop(ocp, robot_instance, q0, mpc_loops)
 
     if debug:

--- a/run_ocp_rnea.py
+++ b/run_ocp_rnea.py
@@ -19,11 +19,14 @@ arm_vel_des = np.array([0.3, 0, 0])
 
 # Tracking goal: linear and angular momentum
 com_goal = np.array([0.3, 0, 0, 0, 0, 0])
-step_height = 0.05
+
+# Swing params
+swing_height = 0.1
+swing_vel_limits = [0.2, -0.4]
 
 # Solver
 solver = "fatrop"
-compile_solver = False
+compile_solver = True
 
 debug = False  # print info
 
@@ -49,7 +52,7 @@ def main():
         nodes=ocp_nodes,
     )
     ocp.set_com_goal(com_goal)
-    ocp.set_step_height(step_height)
+    ocp.set_swing_params(swing_height, swing_vel_limits)
     ocp.set_arm_task(arm_f_des, arm_vel_des)
     ocp.set_weights(robot.Q_diag, robot.R_diag, robot.W_diag)
 
@@ -65,13 +68,11 @@ def main():
     if compile_solver:
         # Evaluate solver function that was compiled
         contact_schedule = ocp.opti.value(ocp.contact_schedule)
-        bezier_schedule = ocp.opti.value(ocp.bezier_schedule)
+        swing_schedule = ocp.opti.value(ocp.swing_schedule)
         n_contacts = ocp.opti.value(ocp.n_contacts)
-        # x_warm_start = ocp.opti.value(ocp.opti.x, ocp.opti.initial())
-        # lam_g_warm_start = ocp.opti.value(ocp.opti.lam_g, ocp.opti.initial())
 
-        params = [x_init, tau_prev, contact_schedule, bezier_schedule, n_contacts,
-                  robot.Q_diag, robot.R_diag, com_goal, step_height]
+        params = [x_init, tau_prev, contact_schedule, swing_schedule, n_contacts, robot.Q_diag,
+                  robot.R_diag, robot.W_diag, com_goal, swing_height, swing_vel_limits]
         if ocp.arm_ee_id:
             params += [arm_f_des, arm_vel_des]
 


### PR DESCRIPTION
- General fix: Use cubic splines like in OCS2 instead of bezier curve. Can specify lift-off and touch-down foot velocities as parameters.
- Update the centroidal dynamics formulation for all RNEA changes (naming, parameters, gait sequence...)