### PR TITLE
Specify tau_nodes in OCP and lock joints

### DIFF
--- a/b2_description/urdf/b2.urdf
+++ b/b2_description/urdf/b2.urdf
@@ -11,7 +11,7 @@
         xyz="0.000458 0.005261 0.000665"
         rpy="0 0 0" />
       <mass
-        value="35.86" />
+        value="33.86" />  <!-- removed 2.0kg for Lidar -->
       <inertia
         ixx="0.27466"
         ixy="-0.000622"
@@ -26,7 +26,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="../meshes/base_link.dae" />
+          filename="../meshes/base_link_no_lidar.dae" />
       </geometry>
       <material
         name="">
@@ -162,7 +162,7 @@
   </link>
   <joint
     name="joint_imu"
-    type="fixed" dont_collapse="true">
+    type="fixed">
     <origin
       xyz="0 -0.02341 0.04927"
       rpy="0 0 0" />
@@ -535,7 +535,7 @@
   </link>
   <joint
     name="FL_foot_joint"
-    type="fixed" dont_collapse="true">
+    type="fixed">
     <origin
       xyz="0 0 -0.35"
       rpy="0 0 0" />
@@ -551,7 +551,7 @@
         xyz="-0.009305 0.010228 0.000264"
         rpy="0 0 0" />
       <mass
-        value="2.256" />
+        value="2.673" />
       <inertia
         ixx="0.0026431"
         ixy="-0.00019234"
@@ -829,7 +829,7 @@
   </link>
   <joint
     name="FR_foot_joint"
-    type="fixed" dont_collapse="true">
+    type="fixed">
     <origin
       xyz="0 0 -0.35"
       rpy="0 0 0" />
@@ -845,7 +845,7 @@
         xyz="0.009305 -0.010228 0.000264"
         rpy="0 0 0" />
       <mass
-        value="2.256" />
+        value="2.673" />
       <inertia
         ixx="0.0026431"
         ixy="-0.00019234"
@@ -1122,7 +1122,7 @@
   </link>
   <joint
     name="RL_foot_joint"
-    type="fixed" dont_collapse="true">
+    type="fixed">
     <origin
       xyz="0 0 -0.35"
       rpy="0 0 0" />
@@ -1415,7 +1415,7 @@
   </link>
   <joint
     name="RR_foot_joint"
-    type="fixed" dont_collapse="true">
+    type="fixed">
     <origin
       xyz="0 -8.6984E-05 -0.35"
       rpy="0 0 0" />

--- a/dynamics_centroidal.py
+++ b/dynamics_centroidal.py
@@ -10,13 +10,11 @@ class DynamicsCentroidal:
             model,
             mass,
             ee_ids,
-            dx_opt_indices,
         ):
         self.model = cpin.Model(model)
         self.data = self.model.createData()
         self.mass = mass
         self.ee_ids = ee_ids
-        self.dx_opt_indices = dx_opt_indices
 
         self.nq = self.model.nq
         self.nv = self.model.nv
@@ -27,10 +25,7 @@ class DynamicsCentroidal:
 
     def state_integrate(self, use_quat_nom=False):
         x = ca.SX.sym("x", 6 + self.nq)
-        dx_opt = ca.SX.sym("dx_opt", len(self.dx_opt_indices))
-
-        dx = ca.SX.zeros(6 + self.nv)  # The other DXs remain zero
-        dx[self.dx_opt_indices] = dx_opt
+        dx = ca.SX.sym("dx", 6 + self.nv)
 
         h = x[:6]
         q = x[6:]
@@ -56,7 +51,7 @@ class DynamicsCentroidal:
         h_next = h + dh
         x_next = ca.vertcat(h_next, q_next)
 
-        return ca.Function("integrate", [x, dx_opt], [x_next], ["x", "dx_opt"], ["x_next"])
+        return ca.Function("integrate", [x, dx], [x_next], ["x", "dx"], ["x_next"])
     
     def state_difference(self):
         x0 = ca.SX.sym("x0", 6 + self.nq)

--- a/dynamics_rnea.py
+++ b/dynamics_rnea.py
@@ -35,7 +35,7 @@ class DynamicsRNEA:
         x_next = ca.vertcat(q_next, v_next)
 
         return ca.Function("integrate", [x, dx], [x_next], ["x", "dx"], ["x_next"])
-    
+
     def state_difference(self):
         x0 = ca.SX.sym("x0", self.nq + self.nv)
         x1 = ca.SX.sym("x1", self.nq + self.nv)
@@ -79,21 +79,6 @@ class DynamicsRNEA:
             f_ext[joint_id] = cpin.Force(f)
 
         tau_rnea = cpin.rnea(self.model, self.data, q, v, a, f_ext)
-
-        # Separate external forces
-        # tau_rnea = cpin.rnea(self.model, self.data, q, v, a)
-        # tau_ext = ca.SX.zeros(self.nv)
-        # for idx, frame_id in enumerate(self.ee_ids):
-        #     J = cpin.computeFrameJacobian(self.model, self.data, q, frame_id, pin.LOCAL_WORLD_ALIGNED)
-        #     J_lin = J[:3]
-        #     f_ext = forces[idx * 3 : (idx + 1) * 3]
-        #     tau_ext += J_lin.T @ f_ext
-        # if arm_ee_id:
-        #     J = cpin.computeFrameJacobian(self.model, self.data, q, arm_ee_id, pin.LOCAL_WORLD_ALIGNED)
-        #     J_lin = J[:3]
-        #     f_ext = forces[-3:]
-        #     tau_ext += J_lin.T @ f_ext
-        # tau_rnea -= tau_ext
 
         return ca.Function("rnea_dyn", [q, v, a, forces], [tau_rnea], ["q", "v", "a", "forces"], ["tau_rnea"])
     

--- a/helpers.py
+++ b/helpers.py
@@ -56,10 +56,13 @@ class Robot:
                 [500] * 6,  # com
                 [0] * 2,  # base x/y
                 [500],  # base z
-                [500] * 2,  # base rot x/y
+                [1000] * 2,  # base rot x/y
                 [0],  # base rot z
-                [50] * self.nj,  # joint pos
+                [10] * 12,  # leg joint pos
             ))
+            if self.arm_ee_id:
+                self.Q_diag = np.concatenate((self.Q_diag, [1] * 6))  # arm joint pos
+
             self.R_diag = np.concatenate((
                 [1e-3] * self.nf,  # forces
                 [1e-1] * self.nj,  # joint vel
@@ -171,23 +174,22 @@ class GaitSequence:
 
         if self.gait_type == "trot":
             self.n_contacts = 2
-            self.swing_T = 0.5 * self.gait_period
+            self.swing_period = 0.5 * self.gait_period
 
         elif self.gait_type == "walk":
             self.n_contacts = 3
-            self.swing_T = 0.25 * self.gait_period
-        
+            self.swing_period = 0.25 * self.gait_period
+
         elif self.gait_type == "stand":
             self.n_contacts = 4
-            self.swing_T = 0.0
-        
+            self.swing_period = 0.0
+
         else:
             raise ValueError(f"Gait: {self.gait_type} not supported")
 
     def get_gait_schedule(self, t_current, dts, nodes):
         """
-        Returns contact and swing schedules for the horizon
-        NOTE: The first node uses dt_sim, the rest use dt
+        Returns contact and swing schedules for the horizon, given the time steps in dts
         """
         contact_schedule = np.ones((4, nodes))  # in_contact: 0 or 1
         swing_schedule = np.zeros((4, nodes))  # swing_phase: from 0 to 1
@@ -198,7 +200,7 @@ class GaitSequence:
                 if i > 0:
                     t += dts[i - 1]
                 gait_phase = t % self.gait_period / self.gait_period
-                swing_phase = t % self.swing_T / self.swing_T
+                swing_phase = t % self.swing_period / self.swing_period
                 if gait_phase < 0.5:
                     # FR, RL in swing
                     contact_schedule[0, i] = 0
@@ -218,7 +220,7 @@ class GaitSequence:
                 if i > 0:
                     t += dts[i - 1]
                 gait_phase = t % self.gait_period / self.gait_period
-                swing_phase = t % self.swing_T / self.swing_T
+                swing_phase = t % self.swing_period / self.swing_period
                 if gait_phase < 0.25:
                     # FL in swing
                     contact_schedule[1, i] = 0
@@ -238,31 +240,35 @@ class GaitSequence:
 
         return contact_schedule, swing_schedule
 
-    def get_bezier_vel_z(self, swing_phase, h_max=0.1):
-        # Implementation from crl-loco
-        vel_z = ca.if_else(
-            swing_phase < 0.5,
-            self.cubic_bezier_derivative(0, h_max, 2 * swing_phase),
-            self.cubic_bezier_derivative(h_max, 0, 2 * swing_phase - 1)
-        ) * 2 / self.swing_T
 
-        return vel_z
+"""
+Swing trajectory helpers
+"""
+def get_bezier_vel_z(swing_phase, swing_period, h_max=0.1):
+    # Implementation from crl-loco
+    vel_z = ca.if_else(
+        swing_phase < 0.5,
+        cubic_bezier_derivative(0, h_max, 2 * swing_phase),
+        cubic_bezier_derivative(h_max, 0, 2 * swing_phase - 1)
+    ) * 2 / swing_period
 
-    def cubic_bezier_derivative(self, p0, p1, phase):
-        return 6 * phase * (1 - phase) * (p1 - p0)
+    return vel_z
 
-    def get_spline_vel_z(self, swing_phase, h_max=0.1, v_liftoff=0.1, v_touchdown=-0.2):
-        mid_time = self.swing_T / 2
-        spline1 = CubicSpline(0, mid_time, 0, v_liftoff, h_max, 0)
-        spline2 = CubicSpline(mid_time, self.swing_T, h_max, 0, 0, v_touchdown)
+def cubic_bezier_derivative(p0, p1, phase):
+    return 6 * phase * (1 - phase) * (p1 - p0)
 
-        vel_z = ca.if_else(
-            swing_phase < 0.5,
-            spline1.velocity(swing_phase * self.swing_T),
-            spline2.velocity(swing_phase * self.swing_T)
-        )
+def get_spline_vel_z(swing_phase, swing_period, h_max=0.1, v_liftoff=0.1, v_touchdown=-0.2):
+    mid_time = swing_period / 2
+    spline1 = CubicSpline(0, mid_time, 0, v_liftoff, h_max, 0)
+    spline2 = CubicSpline(mid_time, swing_period, h_max, 0, 0, v_touchdown)
 
-        return vel_z
+    vel_z = ca.if_else(
+        swing_phase < 0.5,
+        spline1.velocity(swing_phase * swing_period),
+        spline2.velocity(swing_phase * swing_period)
+    )
+
+    return vel_z
 
 
 class CubicSpline:
@@ -270,7 +276,6 @@ class CubicSpline:
     Implementation from OCS2
     """
     def __init__(self, t0, t1, pos0, vel0, pos1, vel1):
-        assert t1 > t0
         self.t0 = t0
         self.t1 = t1
         self.dt = t1 - t0

--- a/ocp_centroidal.py
+++ b/ocp_centroidal.py
@@ -88,13 +88,13 @@ class OCP_Centroidal:
             u = self.U_opt[i]
             err_dx = dx - self.dx_des
             err_u = u - self.u_des
-            obj += 0.5 * err_dx.T @ Q @ err_dx
-            obj += 0.5 * err_u.T @ R @ err_u
+            obj += err_dx.T @ Q @ err_dx
+            obj += err_u.T @ R @ err_u
 
         # Final state
         dx = self.DX_opt[self.nodes]
         err_dx = dx - self.dx_des
-        obj += 0.5 * err_dx.T @ Q @ err_dx
+        obj += err_dx.T @ Q @ err_dx
 
         # CONSTRAINTS
         self.opti.subject_to(self.DX_opt[0] == [0] * self.ndx_opt)  # initial state
@@ -345,6 +345,8 @@ class OCP_Centroidal:
             import osqp
             ocp_params = ca.vertcat(
                 self.opti.value(self.x_init),
+                self.opti.value(self.dt_min),
+                self.opti.value(self.dt_max),
                 ca.vec(self.opti.value(self.contact_schedule)),  # flattened
                 ca.vec(self.opti.value(self.swing_schedule)),  # flattened
                 self.opti.value(self.n_contacts),

--- a/ocp_rnea.py
+++ b/ocp_rnea.py
@@ -384,6 +384,8 @@ class OCP_RNEA:
             ocp_params = ca.vertcat(
                 self.opti.value(self.x_init),
                 self.opti.value(self.tau_prev),
+                self.opti.value(self.dt_min),
+                self.opti.value(self.dt_max),
                 ca.vec(self.opti.value(self.contact_schedule)),  # flattened
                 ca.vec(self.opti.value(self.swing_schedule)),  # flattened
                 self.opti.value(self.n_contacts),

--- a/run_mpc_centroidal.py
+++ b/run_mpc_centroidal.py
@@ -15,12 +15,10 @@ nodes = 10
 dt_min = 0.02  # used for simulation
 dt_max = 0.05
 
-# Only for B2G
+# Tracking target: Base velocity (and arm task for B2G)
+base_vel_des = np.array([0.3, 0, 0, 0, 0, 0])  # linear + angular
 arm_f_des = np.array([0, 0, 0])
-arm_vel_des = np.array([0.2, 0, 0])
-
-# Tracking goal: linear and angular momentum
-com_goal = np.array([0.2, 0, 0, 0, 0, 0])
+arm_vel_des = np.array([0.3, 0.3, 0])
 
 # Swing params
 swing_height = 0.07
@@ -60,9 +58,10 @@ def mpc_loop(ocp, robot_instance, q0, N):
             contact_schedule = ocp.opti.value(ocp.contact_schedule)
             swing_schedule = ocp.opti.value(ocp.swing_schedule)
             n_contacts = ocp.opti.value(ocp.n_contacts)
+            swing_period = ocp.opti.value(ocp.swing_period)
 
-            params = [x_init, dt_min, dt_max, contact_schedule, swing_schedule, n_contacts,
-                      robot.Q_diag, robot.R_diag, com_goal, swing_height, swing_vel_limits]
+            params = [x_init, dt_min, dt_max, contact_schedule, swing_schedule, n_contacts, swing_period,
+                      swing_height, swing_vel_limits, robot.Q_diag, robot.R_diag, base_vel_des]
 
             if ocp.arm_ee_id:
                 params += [arm_f_des, arm_vel_des]
@@ -131,9 +130,8 @@ def main():
     # Setup OCP
     ocp = OCP_Centroidal(robot, nodes)
     ocp.set_time_params(dt_min, dt_max)
-    ocp.set_com_goal(com_goal)
     ocp.set_swing_params(swing_height, swing_vel_limits)
-    ocp.set_arm_task(arm_f_des, arm_vel_des)
+    ocp.set_tracking_target(base_vel_des, arm_f_des, arm_vel_des)
     ocp.set_weights(robot.Q_diag, robot.R_diag)
     ocp = mpc_loop(ocp, robot_instance, q0, mpc_loops)
 

--- a/run_mpc_centroidal.py
+++ b/run_mpc_centroidal.py
@@ -30,7 +30,7 @@ mpc_loops = 50
 # Solver
 solver = "fatrop"
 warm_start = True
-compile_solver = False
+compile_solver = True
 load_compiled_solver = None
 # load_compiled_solver = "libsolver_trot_N8_dt03.so"
 
@@ -41,7 +41,7 @@ def mpc_loop(ocp, robot_instance, q0, N):
     x_init = np.concatenate((np.zeros(6), q0))
     solve_times = []
 
-    if compile_solver or load_compiled_solver:
+    if solver == "fatrop" and compile_solver:
         if load_compiled_solver:
             # Load solver
             solver_function = ca.external("compiled_solver", "codegen/lib/" + load_compiled_solver)

--- a/run_mpc_rnea.py
+++ b/run_mpc_rnea.py
@@ -46,7 +46,7 @@ def mpc_loop(ocp, robot_instance, q0, N):
     solve_times = []
     tau_diffs = []
 
-    if compile_solver or load_compiled_solver:
+    if solver == "fatrop" and compile_solver:
         if load_compiled_solver:
             # Load solver
             solver_function = ca.external("compiled_solver", "codegen/lib/" + load_compiled_solver)

--- a/run_mpc_rnea.py
+++ b/run_mpc_rnea.py
@@ -8,7 +8,7 @@ from helpers import *
 from ocp_rnea import OCP_RNEA
 
 # Problem parameters
-# robot = Go2(dynamics="rnea", reference_pose="standing")
+# robot = B2(dynamics="rnea", reference_pose="standing")
 robot = B2G(dynamics="rnea", reference_pose="standing_with_arm_up", ignore_arm=False)
 gait_type = "trot"
 gait_period = 0.5
@@ -17,12 +17,10 @@ tau_nodes = 2  # remove torques afterwards
 dt_min = 0.01  # used for simulation
 dt_max = 0.05
 
-# Only for B2G
+# Tracking target: Base velocity (and arm task for B2G)
+base_vel_des = np.array([0.3, 0, 0, 0, 0, 0])  # linear + angular
 arm_f_des = np.array([0, 0, 0])
 arm_vel_des = np.array([0.3, 0.3, 0])
-
-# Tracking goal: linear and angular momentum
-com_goal = np.array([0.3, 0, 0, 0, 0, 0])
 
 # Swing params
 swing_height = 0.07
@@ -69,9 +67,10 @@ def mpc_loop(ocp, robot_instance, q0, N):
             contact_schedule = ocp.opti.value(ocp.contact_schedule)
             swing_schedule = ocp.opti.value(ocp.swing_schedule)
             n_contacts = ocp.opti.value(ocp.n_contacts)
+            swing_period = ocp.opti.value(ocp.swing_period)
 
-            params = [x_init, tau_prev, dt_min, dt_max, contact_schedule, swing_schedule, n_contacts,
-                      robot.Q_diag, robot.R_diag, robot.W_diag, com_goal, swing_height, swing_vel_limits]
+            params = [x_init, tau_prev, dt_min, dt_max, contact_schedule, swing_schedule, n_contacts, swing_period,
+                      swing_height, swing_vel_limits, robot.Q_diag, robot.R_diag, robot.W_diag, base_vel_des]
 
             if ocp.arm_ee_id:
                 params += [arm_f_des, arm_vel_des]
@@ -156,9 +155,8 @@ def main():
     # Setup OCP
     ocp = OCP_RNEA(robot, nodes, tau_nodes)
     ocp.set_time_params(dt_min, dt_max)
-    ocp.set_com_goal(com_goal)
     ocp.set_swing_params(swing_height, swing_vel_limits)
-    ocp.set_arm_task(arm_f_des, arm_vel_des)
+    ocp.set_tracking_target(base_vel_des, arm_f_des, arm_vel_des)
     ocp.set_weights(robot.Q_diag, robot.R_diag, robot.W_diag)
     ocp = mpc_loop(ocp, robot_instance, q0, mpc_loops)
 

--- a/run_mpc_rnea.py
+++ b/run_mpc_rnea.py
@@ -8,12 +8,13 @@ from helpers import *
 from ocp_rnea import OCP_RNEA
 
 # Problem parameters
-# robot = Go2(dynamics="rnea", reference_pose="standing")
-robot = B2G(dynamics="rnea", reference_pose="standing_with_arm_up", ignore_arm=False)
+robot = Go2(dynamics="rnea", reference_pose="standing")
+# robot = B2G(dynamics="rnea", reference_pose="standing_with_arm_up", ignore_arm=False)
 gait_type = "trot"
 gait_period = 0.5
-nodes = 10
-dt_min = 0.02  # used for simulation
+nodes = 12
+tau_nodes = 2  # remove torques afterwards
+dt_min = 0.01  # used for simulation
 dt_max = 0.05
 
 # Only for B2G
@@ -35,7 +36,7 @@ solver = "fatrop"
 warm_start = True
 compile_solver = True
 load_compiled_solver = None
-# load_compiled_solver = "libsolver_go2_dt_N12.so"
+# load_compiled_solver = "libsolver_go2_dts_N12_tau2.so"
 
 debug = False  # print info
 plot = True
@@ -153,7 +154,7 @@ def main():
     robot_instance.display(q0)
 
     # Setup OCP
-    ocp = OCP_RNEA(robot, nodes)
+    ocp = OCP_RNEA(robot, nodes, tau_nodes)
     ocp.set_time_params(dt_min, dt_max)
     ocp.set_com_goal(com_goal)
     ocp.set_swing_params(swing_height, swing_vel_limits)

--- a/run_mpc_rnea.py
+++ b/run_mpc_rnea.py
@@ -8,8 +8,8 @@ from helpers import *
 from ocp_rnea import OCP_RNEA
 
 # Problem parameters
-robot = Go2(dynamics="rnea", reference_pose="standing")
-# robot = B2G(dynamics="rnea", reference_pose="standing_with_arm_up", ignore_arm=False)
+# robot = Go2(dynamics="rnea", reference_pose="standing")
+robot = B2G(dynamics="rnea", reference_pose="standing_with_arm_up", ignore_arm=False)
 gait_type = "trot"
 gait_period = 0.5
 nodes = 12
@@ -19,7 +19,7 @@ dt_max = 0.05
 
 # Only for B2G
 arm_f_des = np.array([0, 0, 0])
-arm_vel_des = np.array([0.3, 0, 0])
+arm_vel_des = np.array([0.3, 0.3, 0])
 
 # Tracking goal: linear and angular momentum
 com_goal = np.array([0.3, 0, 0, 0, 0, 0])
@@ -36,7 +36,7 @@ solver = "fatrop"
 warm_start = True
 compile_solver = True
 load_compiled_solver = None
-# load_compiled_solver = "libsolver_go2_dts_N12_tau2.so"
+# load_compiled_solver = "libsolver_b2g_dts_N12_tau2.so"
 
 debug = False  # print info
 plot = True

--- a/run_ocp_centroidal.py
+++ b/run_ocp_centroidal.py
@@ -15,12 +15,10 @@ nodes = 14
 dt_min = 0.02  # used for simulation
 dt_max = 0.05
 
-# Only for B2G
+# Tracking target: Base velocity (and arm task for B2G)
+base_vel_des = np.array([0.3, 0, 0, 0, 0, 0])  # linear + angular
 arm_f_des = np.array([0, 0, 0])
-arm_vel_des = np.array([0.2, 0, 0])
-
-# Tracking goal: linear and angular momentum
-com_goal = np.array([0.2, 0, 0, 0, 0, 0])
+arm_vel_des = np.array([0.3, 0.3, 0])
 
 # Swing params
 swing_height = 0.07
@@ -51,9 +49,8 @@ def main():
     # Setup OCP
     ocp = OCP_Centroidal(robot, nodes)
     ocp.set_time_params(dt_min, dt_max)
-    ocp.set_com_goal(com_goal)
     ocp.set_swing_params(swing_height, swing_vel_limits)
-    ocp.set_arm_task(arm_f_des, arm_vel_des)
+    ocp.set_tracking_target(base_vel_des, arm_f_des, arm_vel_des)
     ocp.set_weights(robot.Q_diag, robot.R_diag)
 
     x_init = np.concatenate((np.zeros(6), q0))
@@ -68,9 +65,10 @@ def main():
         contact_schedule = ocp.opti.value(ocp.contact_schedule)
         swing_schedule = ocp.opti.value(ocp.swing_schedule)
         n_contacts = ocp.opti.value(ocp.n_contacts)
+        swing_period = ocp.opti.value(ocp.swing_period)
 
-        params = [x_init, dt_min, dt_max, contact_schedule, swing_schedule, n_contacts,
-                  robot.Q_diag, robot.R_diag, com_goal, swing_height, swing_vel_limits]
+        params = [x_init, dt_min, dt_max, contact_schedule, swing_schedule, n_contacts, swing_period,
+                  swing_height, swing_vel_limits, robot.Q_diag, robot.R_diag, base_vel_des]
         if ocp.arm_ee_id:
             params += [arm_f_des, arm_vel_des]
 

--- a/run_ocp_centroidal.py
+++ b/run_ocp_centroidal.py
@@ -26,7 +26,7 @@ swing_vel_limits = [0.1, -0.2]
 
 # Solver
 solver = "fatrop"
-compile_solver = False
+compile_solver = True
 
 debug = False  # print info
 
@@ -60,7 +60,7 @@ def main():
     ocp.update_gait_sequence(t_current)
     ocp.init_solver(solver, compile_solver, warm_start=False)
 
-    if compile_solver:
+    if solver == "fatrop" and compile_solver:
         # Evaluate solver function that was compiled
         contact_schedule = ocp.opti.value(ocp.contact_schedule)
         swing_schedule = ocp.opti.value(ocp.swing_schedule)

--- a/run_ocp_rnea.py
+++ b/run_ocp_rnea.py
@@ -15,12 +15,10 @@ tau_nodes = 2  # remove torques afterwards
 dt_min = 0.02  # used for simulation
 dt_max = 0.05
 
-# Only for B2G
+# Tracking target: Base velocity (and arm task for B2G)
+base_vel_des = np.array([0.3, 0, 0, 0, 0, 0])  # linear + angular
 arm_f_des = np.array([0, 0, 0])
 arm_vel_des = np.array([0.3, 0.3, 0])
-
-# Tracking goal: linear and angular momentum
-com_goal = np.array([0.3, 0, 0, 0, 0, 0])
 
 # Swing params
 swing_height = 0.1
@@ -51,9 +49,8 @@ def main():
     # Setup OCP
     ocp = OCP_RNEA(robot, nodes, tau_nodes)
     ocp.set_time_params(dt_min, dt_max)
-    ocp.set_com_goal(com_goal)
     ocp.set_swing_params(swing_height, swing_vel_limits)
-    ocp.set_arm_task(arm_f_des, arm_vel_des)
+    ocp.set_tracking_target(base_vel_des, arm_f_des, arm_vel_des)
     ocp.set_weights(robot.Q_diag, robot.R_diag, robot.W_diag)
 
     x_init = np.concatenate((q0, np.zeros(model.nv)))
@@ -70,9 +67,10 @@ def main():
         contact_schedule = ocp.opti.value(ocp.contact_schedule)
         swing_schedule = ocp.opti.value(ocp.swing_schedule)
         n_contacts = ocp.opti.value(ocp.n_contacts)
+        swing_period = ocp.opti.value(ocp.swing_period)
 
-        params = [x_init, tau_prev, dt_min, dt_max, contact_schedule, swing_schedule, n_contacts, 
-                  robot.Q_diag, robot.R_diag, robot.W_diag, com_goal, swing_height, swing_vel_limits]
+        params = [x_init, tau_prev, dt_min, dt_max, contact_schedule, swing_schedule, n_contacts, swing_period,
+                  swing_height, swing_vel_limits, robot.Q_diag, robot.R_diag, robot.W_diag, base_vel_des]
         if ocp.arm_ee_id:
             params += [arm_f_des, arm_vel_des]
 

--- a/run_ocp_rnea.py
+++ b/run_ocp_rnea.py
@@ -62,7 +62,7 @@ def main():
     ocp.update_gait_sequence(t_current)
     ocp.init_solver(solver, compile_solver, warm_start=False)
 
-    if compile_solver:
+    if solver == "fatrop" and compile_solver:
         # Evaluate solver function that was compiled
         contact_schedule = ocp.opti.value(ocp.contact_schedule)
         swing_schedule = ocp.opti.value(ocp.swing_schedule)

--- a/run_ocp_rnea.py
+++ b/run_ocp_rnea.py
@@ -6,8 +6,8 @@ from helpers import *
 from ocp_rnea import OCP_RNEA
 
 # Problem parameters
-robot = Go2(dynamics="rnea", reference_pose="standing")
-# robot = B2G(dynamics="rnea", reference_pose="standing_with_arm_up", ignore_arm=False)
+# robot = Go2(dynamics="rnea", reference_pose="standing")
+robot = B2G(dynamics="rnea", reference_pose="standing_with_arm_up", ignore_arm=False)
 gait_type = "trot"
 gait_period = 0.5
 nodes = 12
@@ -17,13 +17,13 @@ dt_max = 0.05
 
 # Only for B2G
 arm_f_des = np.array([0, 0, 0])
-arm_vel_des = np.array([0.3, 0, 0])
+arm_vel_des = np.array([0.3, 0.3, 0])
 
 # Tracking goal: linear and angular momentum
 com_goal = np.array([0.3, 0, 0, 0, 0, 0])
 
 # Swing params
-swing_height = 0.07
+swing_height = 0.1
 swing_vel_limits = [0.1, -0.2]
 
 # Solver

--- a/run_ocp_rnea.py
+++ b/run_ocp_rnea.py
@@ -6,11 +6,12 @@ from helpers import *
 from ocp_rnea import OCP_RNEA
 
 # Problem parameters
-# robot = Go2(dynamics="rnea", reference_pose="standing")
-robot = B2G(dynamics="rnea", reference_pose="standing_with_arm_up", ignore_arm=False)
+robot = Go2(dynamics="rnea", reference_pose="standing")
+# robot = B2G(dynamics="rnea", reference_pose="standing_with_arm_up", ignore_arm=False)
 gait_type = "trot"
 gait_period = 0.5
-nodes = 14
+nodes = 12
+tau_nodes = 2  # remove torques afterwards
 dt_min = 0.02  # used for simulation
 dt_max = 0.05
 
@@ -48,7 +49,7 @@ def main():
     pin.computeAllTerms(model, data, q0, np.zeros(model.nv))
 
     # Setup OCP
-    ocp = OCP_RNEA(robot, nodes)
+    ocp = OCP_RNEA(robot, nodes, tau_nodes)
     ocp.set_time_params(dt_min, dt_max)
     ocp.set_com_goal(com_goal)
     ocp.set_swing_params(swing_height, swing_vel_limits)


### PR DESCRIPTION
- Before when the torques were removed from the constraints they were still optimization variables. Now they are completely removed, actually making the problem smaller.
- Lock joints when initializing Pinocchio robot model (no need to store opt_indices anymore).
- Add swing period as parameter, so can adapt gait period on hardware.